### PR TITLE
Cli11+spdlog

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,8 @@ endif ()
 # build
 project(server017 VERSION 0.0.1 DESCRIPTION "Server of team 17 for the Sopra")
 
+find_package(spdlog REQUIRED)
+
 file(GLOB_RECURSE SOURCES
         ${CMAKE_SOURCE_DIR}/src/*.cpp
         ${CMAKE_SOURCE_DIR}/src/*.hpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,8 @@ file(GLOB_RECURSE SOURCES
         ${CMAKE_SOURCE_DIR}/src/*.hpp
 )
 
+SET(${LIBS} spdlog)
+
 include_directories(${CMAKE_SOURCE_DIR}/src)
 add_executable(${PROJECT_NAME} ${SOURCES})
 target_link_libraries(${PROJECT_NAME} ${LIBS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ endif ()
 project(server017 VERSION 0.0.1 DESCRIPTION "Server of team 17 for the Sopra")
 
 find_package(spdlog REQUIRED)
+find_package(CLI11 REQUIRED)
 
 file(GLOB_RECURSE SOURCES
         ${CMAKE_SOURCE_DIR}/src/*.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ file(GLOB_RECURSE SOURCES
         ${CMAKE_SOURCE_DIR}/src/*.cpp
         ${CMAKE_SOURCE_DIR}/src/*.hpp)
 
-SET(${LIBS} LIBS spdlog::spdlog CLI11::CLI11 stdc++fs)
+SET(LIBS spdlog::spdlog CLI11::CLI11 stdc++fs)
 
 include_directories(${CMAKE_SOURCE_DIR}/src)
 add_executable(${PROJECT_NAME} ${SOURCES})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,6 @@ else ()
     message("############################\n")
 endif ()
 
-# build
 project(server017 VERSION 0.0.1 DESCRIPTION "Server of team 17 for the Sopra")
 
 find_package(spdlog REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,31 @@
+cmake_minimum_required(VERSION 3.10)
+
+# build options
+set(CMAKE_CXX_STANDARD 17)
+
+if (NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE Release)
+endif (NOT CMAKE_BUILD_TYPE)
+
+set(CMAKE_CXX_FLAGS "-Wall -Wextra -Wpedantic -Werror -mtune=native -march=native")
+if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+    message("\n##########################")
+    message("###### DEBUG BUILD #######")
+    message("##########################\n")
+else ()
+    message("\n############################")
+    message("###### RELEASE BUILD #######")
+    message("############################\n")
+endif ()
+
+# build
+project(server017 VERSION 0.0.1 DESCRIPTION "Server of team 17 for the Sopra")
+
+file(GLOB_RECURSE SOURCES
+        ${CMAKE_SOURCE_DIR}/src/*.cpp
+        ${CMAKE_SOURCE_DIR}/src/*.hpp
+)
+
+include_directories(${CMAKE_SOURCE_DIR}/src)
+add_executable(${PROJECT_NAME} ${SOURCES})
+target_link_libraries(${PROJECT_NAME} ${LIBS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,10 +25,9 @@ find_package(CLI11 REQUIRED)
 
 file(GLOB_RECURSE SOURCES
         ${CMAKE_SOURCE_DIR}/src/*.cpp
-        ${CMAKE_SOURCE_DIR}/src/*.hpp
-)
+        ${CMAKE_SOURCE_DIR}/src/*.hpp)
 
-SET(${LIBS} spdlog)
+SET(${LIBS} LIBS spdlog::spdlog CLI11::CLI11 stdc++fs)
 
 include_directories(${CMAKE_SOURCE_DIR}/src)
 add_executable(${PROJECT_NAME} ${SOURCES})

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ be also the option to install it through a docker container.
  * C++17 compatible Compiler (e.g. GCC-8)
  * CMake (at least version 3.10)
  * GNU-Make
+ * [spdlog](https://github.com/gabime/spdlog/)
+ * [CLI11](https://github.com/CLIUtils/CLI11)
 
 #### Compiling the application
 Create a directory for the build and change into this. The name of this 
@@ -31,7 +33,7 @@ make
 ```
 Test the installation by executing the server.
 ```
-./server017
+./server017 -h
 ```
 
 ## Usage

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,50 @@
+/**
+ * @file   main.cpp
+ * @author Dominik Authaler
+ * @date   01.04.2020 (creation)
+ * @brief
+ */
+
+#include "CLI/CLI.hpp"
+
+constexpr int maxVerbosity     =  5;
+constexpr int defaultVerbosity =  1;
+constexpr int defaultPort      = 17;
+
+int main(int argc, char *argv[]) {
+    CLI::App app;
+
+    std::string  characterPath;
+    std::string  matchPath;
+    std::string  scenarioPath;
+
+    unsigned int verbosity = defaultVerbosity;
+    unsigned int port      = defaultPort;
+
+    std::vector<std::string> additionalOptions;
+
+    app.add_option("--config-charset,-c", characterPath,
+            "Path to the character configuration file")->required()->check(CLI::ExistingFile);
+    app.add_option("--config-match,-m", matchPath,
+            "Path to the match configuration file")->required()->check(CLI::ExistingFile);
+    app.add_option("--config-scenario,-s", scenarioPath,
+            "Path to the scenario configuration file")->required()->check(CLI::ExistingFile);
+    app.add_option("--verbosity,-v", verbosity,
+            "Logging verbosity")->check(CLI::Range(0, maxVerbosity));
+    app.add_option("--port,-p", port, "Port used by the server");
+    app.add_option("--x", additionalOptions, "Additional key value pairs");
+
+    CLI11_PARSE(app, argc, argv);
+
+    std::cout << "Character configuration: " << characterPath << std::endl;
+    std::cout << "Match configuration:     " << matchPath     << std::endl;
+    std::cout << "Scenario configuration:  " << scenarioPath  << std::endl;
+    std::cout << "Verbosity:               " << verbosity     << std::endl;
+    std::cout << "Port:                    " << port          << std::endl;
+    std::cout << "Additional options: " << std::endl;
+    for (unsigned int i = 0; i < additionalOptions.size(); i+= 2) {
+        std::cout << "Key: " << additionalOptions[i] << "\tValue: " << additionalOptions[i+1] << std::endl;
+    }
+
+    return 0;
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,35 +1,36 @@
 /**
  * @file   main.cpp
- * @author Dominik Authaler
+ * @author Dominik Authaler, Jonas Otto
  * @date   01.04.2020 (creation)
  */
 
 #include "CLI/CLI.hpp"
 #include "spdlog/spdlog.h"
-constexpr unsigned int maxVerbosity     =  5;
-constexpr unsigned int defaultVerbosity =  1;
-constexpr unsigned int defaultPort      = 17;
+
+constexpr unsigned int maxVerbosity = 5;
+constexpr unsigned int defaultVerbosity = 1;
+constexpr unsigned int defaultPort = 17;
 
 int main(int argc, char *argv[]) {
     CLI::App app;
 
-    std::string  characterPath;
-    std::string  matchPath;
-    std::string  scenarioPath;
+    std::string characterPath;
+    std::string matchPath;
+    std::string scenarioPath;
 
     unsigned int verbosity = defaultVerbosity;
-    unsigned int port      = defaultPort;
+    unsigned int port = defaultPort;
 
     std::vector<std::string> additionalOptions;
 
     app.add_option("--config-charset,-c", characterPath,
-            "Path to the character configuration file")->required()->check(CLI::ExistingFile);
+                   "Path to the character configuration file")->required()->check(CLI::ExistingFile);
     app.add_option("--config-match,-m", matchPath,
-            "Path to the match configuration file")->required()->check(CLI::ExistingFile);
+                   "Path to the match configuration file")->required()->check(CLI::ExistingFile);
     app.add_option("--config-scenario,-s", scenarioPath,
-            "Path to the scenario configuration file")->required()->check(CLI::ExistingFile);
+                   "Path to the scenario configuration file")->required()->check(CLI::ExistingFile);
     app.add_option("--verbosity,-v", verbosity,
-            "Logging verbosity")->check(CLI::Range(maxVerbosity));
+                   "Logging verbosity")->check(CLI::Range(maxVerbosity));
     app.add_option("--port,-p", port, "Port used by the server");
     app.add_option("--x", additionalOptions, "Additional key value pairs");
 
@@ -43,11 +44,11 @@ int main(int argc, char *argv[]) {
     spdlog::info(" -> character configuration: {}", characterPath);
     spdlog::info(" -> match configuration:     {}", matchPath);
     spdlog::info(" -> scenario configuration:  {}", scenarioPath);
-    spdlog::info(" -> verbosity: {}", verbosity);
-    spdlog::info(" -> port: {}", port);
+    spdlog::info(" -> verbosity:               {}", verbosity);
+    spdlog::info(" -> port:                    {}", port);
     spdlog::info(" -> additional:");
-    for (unsigned int i = 0; i < additionalOptions.size(); i+= 2) {
-        spdlog::info("\t {} = {}", additionalOptions[i], additionalOptions[i+1]);
+    for (unsigned int i = 0; i + 1 < additionalOptions.size(); i+= 2) {
+        spdlog::info("\t {} = {}", additionalOptions.at(i), additionalOptions.at(i+1));
     }
 
     return 0;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,14 +2,13 @@
  * @file   main.cpp
  * @author Dominik Authaler
  * @date   01.04.2020 (creation)
- * @brief
  */
 
 #include "CLI/CLI.hpp"
-
-constexpr int maxVerbosity     =  5;
-constexpr int defaultVerbosity =  1;
-constexpr int defaultPort      = 17;
+#include "spdlog/spdlog.h"
+constexpr unsigned int maxVerbosity     =  5;
+constexpr unsigned int defaultVerbosity =  1;
+constexpr unsigned int defaultPort      = 17;
 
 int main(int argc, char *argv[]) {
     CLI::App app;
@@ -30,20 +29,21 @@ int main(int argc, char *argv[]) {
     app.add_option("--config-scenario,-s", scenarioPath,
             "Path to the scenario configuration file")->required()->check(CLI::ExistingFile);
     app.add_option("--verbosity,-v", verbosity,
-            "Logging verbosity")->check(CLI::Range(0, maxVerbosity));
+            "Logging verbosity")->check(CLI::Range(maxVerbosity));
     app.add_option("--port,-p", port, "Port used by the server");
     app.add_option("--x", additionalOptions, "Additional key value pairs");
 
     CLI11_PARSE(app, argc, argv);
 
-    std::cout << "Character configuration: " << characterPath << std::endl;
-    std::cout << "Match configuration:     " << matchPath     << std::endl;
-    std::cout << "Scenario configuration:  " << scenarioPath  << std::endl;
-    std::cout << "Verbosity:               " << verbosity     << std::endl;
-    std::cout << "Port:                    " << port          << std::endl;
-    std::cout << "Additional options: " << std::endl;
+    spdlog::info("Server called with following arguments: ");
+    spdlog::info(" -> character configuration: {}", characterPath);
+    spdlog::info(" -> match configuration:     {}", matchPath);
+    spdlog::info(" -> scenario configuration:  {}", scenarioPath);
+    spdlog::info(" -> verbosity: {}", verbosity);
+    spdlog::info(" -> port: {}", port);
+    spdlog::info(" -> additional:");
     for (unsigned int i = 0; i < additionalOptions.size(); i+= 2) {
-        std::cout << "Key: " << additionalOptions[i] << "\tValue: " << additionalOptions[i+1] << std::endl;
+        spdlog::info("\t {} = {}", additionalOptions[i], additionalOptions[i+1]);
     }
 
     return 0;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -33,7 +33,11 @@ int main(int argc, char *argv[]) {
     app.add_option("--port,-p", port, "Port used by the server");
     app.add_option("--x", additionalOptions, "Additional key value pairs");
 
-    CLI11_PARSE(app, argc, argv);
+    try {
+        app.parse(argc, argv);
+    } catch (const CLI::ParseError &e) {
+        return app.exit(e);
+    }
 
     spdlog::info("Server called with following arguments: ");
     spdlog::info(" -> character configuration: {}", characterPath);


### PR DESCRIPTION
Entsprechend der Diskussion im [geschlossenen Pull Request](https://github.com/SoPra-Team-17/Server/pull/3) und den beiden Issues zu Logger und Command Line Parser hier jetzt die Kombination aus CLI11 und spdlog. Beides muss systemweit installiert sein.