### PR TITLE
CLI11 use std::filesystem

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -9,7 +9,7 @@ jobs:
             max-parallel: 4
             fail-fast: false
             matrix:
-              cxx: [g++-8]
+              cxx: [g++-8, clang++]
         env:
           CXX: ${{ matrix.cxx }}
         steps:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,7 +8,10 @@ jobs:
         strategy:
             max-parallel: 4
             fail-fast: false
-
+            matrix:
+              cxx: [g++-7, g++-8]
+        env:
+          CXX: ${{ matrix.cxx }}
         steps:
         - uses: actions/checkout@v2
           with:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -9,7 +9,7 @@ jobs:
             max-parallel: 4
             fail-fast: false
             matrix:
-              cxx: [g++-7, g++-8]
+              cxx: [g++-8]
         env:
           CXX: ${{ matrix.cxx }}
         steps:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,14 +20,19 @@ endif ()
 
 project(server017 VERSION 0.0.1 DESCRIPTION "Server of team 17 for the Sopra")
 
+# Libraries
+# spdlog
 find_package(spdlog REQUIRED)
+SET(LIBS ${LIBS} spdlog::spdlog)
+
+# CLI11
 find_package(CLI11 REQUIRED)
+add_definitions(-DCLI11_HAS_FILESYSTEM=1)
+SET(LIBS ${LIBS} CLI11::CLI11 stdc++fs)
 
 file(GLOB_RECURSE SOURCES
         ${CMAKE_SOURCE_DIR}/src/*.cpp
         ${CMAKE_SOURCE_DIR}/src/*.hpp)
-
-SET(LIBS spdlog::spdlog CLI11::CLI11 stdc++fs)
 
 include_directories(${CMAKE_SOURCE_DIR}/src)
 add_executable(${PROJECT_NAME} ${SOURCES})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.10)
 
 # build options
 set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 if (NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Release)

--- a/installDependencies.sh
+++ b/installDependencies.sh
@@ -3,6 +3,12 @@
 # Setup
 # Exit the script if any command fails
 set -e
+# Update apt
+sudo apt update
+# GCC 8
+sudo apt install gcc-8 g++-8
+export CC=gcc-8
+export CXX=g++-8
 
 # CLI11
 cd /tmp
@@ -18,7 +24,7 @@ cd /tmp
 git clone https://github.com/gabime/spdlog.git
 cd spdlog
 mkdir build && cd build
-cmake ..
+cmake -DSPDLOG_BUILD_TESTS=false -DSPDLOG_BUILD_EXAMPLE=false ..
 make -j$(nproc)
 sudo make install
 

--- a/installDependencies.sh
+++ b/installDependencies.sh
@@ -15,7 +15,7 @@ cd /tmp
 git clone https://github.com/CLIUtils/CLI11.git
 cd CLI11
 mkdir build && cd build
-cmake -DCLI11_BUILD_TESTS=false ..
+cmake -DCLI11_BUILD_TESTS=false -DCLI11_BUILD_DOCS=false -DCLI11_BUILD_EXAMPLES=false ..
 make -j$(nproc)
 sudo make install
 

--- a/installDependencies.sh
+++ b/installDependencies.sh
@@ -9,6 +9,8 @@ sudo apt update
 sudo apt install gcc-8 g++-8
 export CC=gcc-8
 export CXX=g++-8
+# clang
+sudo apt install clang
 
 # CLI11
 cd /tmp


### PR DESCRIPTION
use std::filesystem in CLI11 (not used in GCC < 9 by default since https://github.com/CLIUtils/CLI11/commit/b9a2f320b912aae623c4acddea06cba399b98654\#diff-667c3aea9ca4a9271a44b86532619229R36)

außerdem: keine examples/tests mehr bei CLI11 und spdlog, notwendigerweise GCC8 als dependency, zusätzlich clang in die testmatrix, kann ja nicht schaden.