### PR TITLE
Npc gadgets

### DIFF
--- a/src/Server.hpp
+++ b/src/Server.hpp
@@ -20,6 +20,8 @@
 #include <random>
 #include<Actions.hpp>
 
+constexpr unsigned int defaultMaxNPCs = 8;
+
 
 class Server : public afsm::def::state_machine<Server> {
     public:
@@ -104,6 +106,8 @@ class Server : public afsm::def::state_machine<Server> {
          * Holds all characters and gadgets currently available to choose from.
          */
         ChoiceSet choiceSet;
+
+        unsigned int maxNumberOfNPCs = defaultMaxNPCs;
 
     private:
         const static std::map<unsigned int, spdlog::level::level_enum> verbosityMap;

--- a/src/game/ChoiceHandling.hpp
+++ b/src/game/ChoiceHandling.hpp
@@ -126,7 +126,11 @@ namespace actions {
                 }
             }
 
+            // for each character, insert it into the character set if it has been chosen by a client or
+            // assigned to the NPC faction
             for (const auto &c : charInfos) {
+                // search for the character UUID in the list of characters of the players and the NPCs and
+                // set it's faction to the corresponding value
                 if (std::find(charsP1.begin(), charsP1.end(), c.getCharacterId()) != charsP1.end()) {
                     faction = spy::character::FactionEnum::PLAYER1;
                 } else if (std::find(charsP2.begin(), charsP2.end(), c.getCharacterId()) != charsP2.end()) {

--- a/src/game/ChoiceHandling.hpp
+++ b/src/game/ChoiceHandling.hpp
@@ -101,7 +101,7 @@ namespace actions {
             const std::vector<spy::character::CharacterInformation> &charInfos =
                     root_machine(fsm).characterInformations;
             spy::gameplay::State &gameState = root_machine(fsm).gameState;
-            ChoiceSet &choiceSet = root_machine(fsm).choiceSet;
+            const ChoiceSet &choiceSet = root_machine(fsm).choiceSet;
             const unsigned int maxNumberOfNPCs = root_machine(fsm).maxNumberOfNPCs;
 
             auto charsP1 = s.characterChoices.at(playerIds.at(Player::one));

--- a/src/game/ChoicePhaseFSM.hpp
+++ b/src/game/ChoicePhaseFSM.hpp
@@ -59,6 +59,7 @@ struct ChoicePhase : afsm::def::state_def<ChoicePhase> {
         MessageRouter &router = root_machine(fsm).router;
         const std::map<Player, spy::util::UUID> &playerIds = root_machine(fsm).playerIds;
 
+        choiceSet.clear();
         choiceSet.addForSelection(characterInformations, possibleGadgets);
 
         auto idP1 = playerIds.at(Player::one);

--- a/src/util/ChoiceSet.cpp
+++ b/src/util/ChoiceSet.cpp
@@ -145,4 +145,18 @@ unsigned int ChoiceSet::getNumberOfGadgets() const {
     return gadgets.size();
 }
 
+std::list<spy::util::UUID> ChoiceSet::getRemainingCharacters() const {
+    std::lock_guard<std::mutex> guard(selectionMutex);
+    return characters;
+}
 
+std::list<spy::gadget::GadgetEnum> ChoiceSet::getRemainingGadgets() const {
+    std::lock_guard<std::mutex> guard(selectionMutex);
+    return gadgets;
+}
+
+void ChoiceSet::clear() {
+    std::lock_guard<std::mutex> guard(selectionMutex);
+    characters.clear();
+    gadgets.clear();
+}

--- a/src/util/ChoiceSet.hpp
+++ b/src/util/ChoiceSet.hpp
@@ -125,6 +125,22 @@ class ChoiceSet {
          */
         [[nodiscard]] unsigned int getNumberOfGadgets() const;
 
+        /**
+         * Getter for the remaining character uuids.
+         * @return List of remaining character uuids.
+         */
+        std::list<spy::util::UUID> getRemainingCharacters() const;
+
+        /**
+         * Getter for the remaining gadgets.
+         * @return List of remaining gadgets.
+         */
+        std::list<spy::gadget::GadgetEnum> getRemainingGadgets() const;
+
+        /**
+         * Clears the internal lists of character uuids and gadgets.
+         */
+        void clear();
 
     private:
         std::list<spy::util::UUID> characters;


### PR DESCRIPTION
fixes #70 

Aktuell ist es so, dass das Nugget, der Mirror of Wilderness und das Chicken Feed Gadget nicht an die NPCs verteilt werden, da diese damit aus meiner Sicht nichts anfangen.