### PR TITLE
send game status when spectator connects during game

### DIFF
--- a/src/Actions.hpp
+++ b/src/Actions.hpp
@@ -222,38 +222,6 @@ namespace actions {
             router.broadcastMessage(spy::network::messages::GamePause{{}, false, isForced});
         }
     };
-
-    /**
-     * Sends the spectator the current game state.
-     * @note The action depends on information of the game FSM, specifically the game phase.
-     */
-    struct sendSpectatorState {
-        template<typename Event, typename FSM, typename SourceState, typename TargetState>
-        void operator()(Event &e, FSM &fsm, SourceState &, TargetState &) {
-            MessageRouter &router = root_machine(fsm).router;
-            spy::network::messages::Hello helloMsg = e;
-
-            spdlog::debug("Checking if sending of spectator state is possible");
-
-            if (!root_machine(fsm).isIngame) {
-                // game hasn't started yet, thus sending an initial state is not possible
-                return;
-            }
-
-            spy::gameplay::State state = root_machine(fsm).gameState;
-            bool gameOver = spy::util::RoundUtils::isGameOver(state);
-            state.setKnownSafeCombinations({});
-            spy::network::messages::GameStatus stateMsg(
-                    helloMsg.getClientId(),
-                    fsm.activeCharacter,
-                    fsm.operations,
-                    state,
-                    gameOver);
-
-            router.sendMessage(stateMsg);
-            spdlog::debug("Send initial state to spectator {}", helloMsg.getClientId());
-        }
-    };
 }
 
 #endif //SERVER017_ACTIONS_HPP

--- a/src/Server.hpp
+++ b/src/Server.hpp
@@ -62,10 +62,10 @@ class Server : public afsm::def::state_machine<Server> {
         >;
 
         using internal_transitions = transition_table <
-        // Event                                           Action                  Guard
+        // Event                                           Action                           Guard
         // Reply to MetaInformation request at any time during the game
         in<spy::network::messages::RequestMetaInformation, actions::sendMetaInformation>,
-        in<spy::network::messages::Hello,                  actions::HelloReply,    guards::isSpectator>>;
+        in<spy::network::messages::Hello,                  actions::HelloReply,             guards::isSpectator>>;
         // @formatter:on
 
         unsigned int verbosity;

--- a/src/game/GameFSM.hpp
+++ b/src/game/GameFSM.hpp
@@ -283,6 +283,7 @@ class GameFSM : public afsm::def::state_machine<GameFSM> {
             // Server forced unpause
             tr<paused,              events::forceUnpause,                     waitingForOperation, actions::unpauseGame>
             >;
+            // @formatter:on
         };
 
         using initial_state = decltype(choicePhase);

--- a/src/game/GameFSM.hpp
+++ b/src/game/GameFSM.hpp
@@ -220,7 +220,7 @@ class GameFSM : public afsm::def::state_machine<GameFSM> {
 
                 using internal_transitions = transition_table <
                 // Event                          Action                                                               Guard
-                in<spy::network::messages::Hello, actions::multiple<actions::HelloReply, actions::sendSpectatorState>, guards::isSpectator>>;
+                in<spy::network::messages::Hello, actions::multiple<actions::HelloReply, actions::broadcastState>, guards::isSpectator>>;
                 // @formatter:on
             };
 
@@ -241,7 +241,7 @@ class GameFSM : public afsm::def::state_machine<GameFSM> {
                 in<events::triggerNPCmove,                actions::multiple<actions::generateNPCMove>>,
                 in<events::triggerCatMove,                actions::multiple<actions::executeCatMove, actions::broadcastState, actions::requestNextOperation>>,
                 in<events::triggerJanitorMove,            actions::multiple<actions::executeJanitorMove, actions::broadcastState, actions::requestNextOperation>>,
-                in<spy::network::messages::Hello, actions::multiple<actions::HelloReply, actions::sendSpectatorState>,                                            guards::isSpectator>>;
+                in<spy::network::messages::Hello, actions::multiple<actions::HelloReply, actions::broadcastState>,                                                guards::isSpectator>>;
                 // @formatter:on
             };
 
@@ -263,8 +263,8 @@ class GameFSM : public afsm::def::state_machine<GameFSM> {
                 Timer timer;
 
                 using internal_transitions = transition_table <
-                // Event                          Action                                                               Guard
-                in<spy::network::messages::Hello, actions::multiple<actions::HelloReply, actions::sendSpectatorState>, guards::isSpectator>>;
+                // Event                          Action                                                           Guard
+                in<spy::network::messages::Hello, actions::multiple<actions::HelloReply, actions::broadcastState>, guards::isSpectator>>;
                 // @formatter:on
             };
 

--- a/src/game/GameFSM.hpp
+++ b/src/game/GameFSM.hpp
@@ -64,7 +64,7 @@ class GameFSM : public afsm::def::state_machine<GameFSM> {
 
             // @formatter:off
             using internal_transitions = transition_table <
-            //  Event                                   Action                                                     Guard
+            //  Event                                   Action                                                                  Guard
             in<spy::network::messages::EquipmentChoice, actions::handleEquipmentChoice, and_<not_<guards::lastEquipmentChoice>, guards::equipmentChoiceValid>>
             >;
             // @formatter:on
@@ -217,6 +217,11 @@ class GameFSM : public afsm::def::state_machine<GameFSM> {
 
                     root_machine(fsm).process_event(events::roundInitDone{});
                 }
+
+                using internal_transitions = transition_table <
+                // Event                          Action                                                               Guard
+                in<spy::network::messages::Hello, actions::multiple<actions::HelloReply, actions::sendSpectatorState>, guards::isSpectator>>;
+                // @formatter:on
             };
 
             /**
@@ -235,8 +240,8 @@ class GameFSM : public afsm::def::state_machine<GameFSM> {
                 in<spy::network::messages::GameOperation, actions::multiple<actions::handleOperation, actions::broadcastState, actions::requestNextOperation>,    guards::operationValid>,
                 in<events::triggerNPCmove,                actions::multiple<actions::generateNPCMove>>,
                 in<events::triggerCatMove,                actions::multiple<actions::executeCatMove, actions::broadcastState, actions::requestNextOperation>>,
-                in<events::triggerJanitorMove,            actions::multiple<actions::executeJanitorMove, actions::broadcastState, actions::requestNextOperation>>
-                >;
+                in<events::triggerJanitorMove,            actions::multiple<actions::executeJanitorMove, actions::broadcastState, actions::requestNextOperation>>,
+                in<spy::network::messages::Hello, actions::multiple<actions::HelloReply, actions::sendSpectatorState>,                                            guards::isSpectator>>;
                 // @formatter:on
             };
 
@@ -256,6 +261,11 @@ class GameFSM : public afsm::def::state_machine<GameFSM> {
 
                 bool serverEnforced = false;
                 Timer timer;
+
+                using internal_transitions = transition_table <
+                // Event                          Action                                                               Guard
+                in<spy::network::messages::Hello, actions::multiple<actions::HelloReply, actions::sendSpectatorState>, guards::isSpectator>>;
+                // @formatter:on
             };
 
             using initial_state = roundInit;
@@ -273,7 +283,6 @@ class GameFSM : public afsm::def::state_machine<GameFSM> {
             // Server forced unpause
             tr<paused,              events::forceUnpause,                     waitingForOperation, actions::unpauseGame>
             >;
-            // @formatter:on
         };
 
         using initial_state = decltype(choicePhase);
@@ -289,10 +298,6 @@ class GameFSM : public afsm::def::state_machine<GameFSM> {
         tr<decltype(choicePhase), spy::network::messages::ItemChoice,      equipPhase, actions::multiple<actions::handleChoice, actions::createCharacterSet>, and_<guards::lastChoice, guards::choiceValid>>,
         tr<equipPhase,            spy::network::messages::EquipmentChoice, gamePhase,  actions::handleEquipmentChoice,                                        and_<guards::lastEquipmentChoice, guards::equipmentChoiceValid>>
         >;
-
-        using internal_transitions = transition_table <
-        // Event                                           Action
-        in<spy::network::messages::RequestMetaInformation, actions::sendMetaInformation>>;
         // @formatter:on
 };
 

--- a/test/client/main.cpp
+++ b/test/client/main.cpp
@@ -188,31 +188,38 @@ struct TestClient {
 };
 
 int main() {
-    auto c1 = TestClient("Player 1");
-    auto c2 = TestClient("Player 2", spy::network::RoleEnum::AI);
-    auto c3 = TestClient("Spectator", spy::network::RoleEnum::SPECTATOR);
+    auto p1 = TestClient("Player 1");
+    auto p2 = TestClient("Player 2", spy::network::RoleEnum::AI);
+    auto s1 = TestClient("Spectator1", spy::network::RoleEnum::SPECTATOR);
+    auto s2 = TestClient("Spectator2", spy::network::RoleEnum::SPECTATOR);
+    auto s3 = TestClient("Spectator3", spy::network::RoleEnum::SPECTATOR);
 
-    c1.sendHello();
+    p1.sendHello();
+    s1.sendHello();                 // hello before game start --> no game status expected
     std::this_thread::sleep_for(std::chrono::seconds{1});
-    c2.sendHello();
-    std::this_thread::sleep_for(std::chrono::seconds{1});
-    c3.sendHello();
+    p2.sendHello();
+    std::this_thread::sleep_for(std::chrono::milliseconds {100});
+    s2.sendHello();                 // hello during choice phases --> no game status expected
 
     std::this_thread::sleep_for(std::chrono::seconds{5});
 
-    c1.requestMetaInformation();
-    c2.requestMetaInformation();
-    c3.requestMetaInformation();
+    p1.requestMetaInformation();
+    p2.requestMetaInformation();
+    s1.requestMetaInformation();
 
     // Pause, unpause within time limit
-    c1.sendRequestPause(true);
+    p1.sendRequestPause(true);
     std::this_thread::sleep_for(std::chrono::seconds{3});
     // Unpause
-    c1.sendRequestPause(false);
+    p1.sendRequestPause(false);
 
     // Pause, wait for time limit to expire
-    c1.sendRequestPause(true);
+    p1.sendRequestPause(true);
 
     std::cout << "done" << std::endl;
+
+    std::this_thread::sleep_for(std::chrono::seconds{10});
+    s3.sendHello();                 // hello during game phase --> game status expected
+
     std::this_thread::sleep_for(std::chrono::hours{100});
 }


### PR DESCRIPTION
fixes #12 

Es war leider nicht möglich, das ganze als internal transition in der Server FSM zu behandeln, da Teile der Game Status Nachricht nur innerhalb der Game Phase sichtbar sind.
Als internal transition für die game FSM funktionierte es auch nicht, da die FSM dann falsch gesetzt wird. Stattdessen ist es nun in allen relevanten Zuständen der GameFSM drin, und "überdeckt" die Aktion der Server FSM, welche in sämtlichen anderen Fällen die Hello Reply sendet, aber den Status weglässt, da kein Spiel läuft.
