### PR TITLE
fix turn order after janitor moves

### DIFF
--- a/src/game/OperationHandling.hpp
+++ b/src/game/OperationHandling.hpp
@@ -272,7 +272,8 @@ namespace actions {
 
             auto catAction = ActionGenerator::generateCatAction(state);
 
-            ActionExecutor::executeCat(state, *std::dynamic_pointer_cast<const CatAction>(catAction));
+            auto res = ActionExecutor::executeCat(state, *std::dynamic_pointer_cast<const CatAction>(catAction));
+            fsm.operations.push_back(res);
         }
     };
 
@@ -287,12 +288,29 @@ namespace actions {
             using spy::gameplay::ActionExecutor;
             using spy::gameplay::ActionGenerator;
             using spy::gameplay::JanitorAction;
+            using spy::util::GameLogicUtils;
 
             State &state = root_machine(fsm).gameState;
 
             auto janitorAction = ActionGenerator::generateJanitorAction(state);
+            auto janitorTarget = GameLogicUtils::getInCharacterSetByCoordinates(state.getCharacters(),
+                                                                                janitorAction->getTarget());
 
-            ActionExecutor::executeJanitor(state, *std::dynamic_pointer_cast<const JanitorAction>(janitorAction));
+            auto res = ActionExecutor::executeJanitor(state,
+                                                      *std::dynamic_pointer_cast<const JanitorAction>(janitorAction));
+
+            spdlog::debug("Janitor removes {}", janitorTarget->getName());
+
+            fsm.operations.push_back(res);
+
+            // remove character from the list of remaining characters
+            auto it = std::find(fsm.remainingCharacters.begin(), fsm.remainingCharacters.end(),
+                                janitorTarget->getCharacterId());
+            if (it != fsm.remainingCharacters.end()) {
+                fsm.remainingCharacters.erase(it);
+                janitorTarget->setActionPoints(0);
+                janitorTarget->setMovePoints(0);
+            }
         }
     };
 }


### PR DESCRIPTION
The removed character now gets erased from the list of remaining characters. Thus fixes #99 