### PR TITLE
Fix disconnect to empty lobby transition

### DIFF
--- a/src/Actions.hpp
+++ b/src/Actions.hpp
@@ -41,6 +41,10 @@ namespace actions {
         template<typename Event, typename FSM, typename SourceState, typename TargetState>
         void operator()(Event &&event, FSM &fsm, SourceState &, TargetState &) {
             spy::network::messages::Hello &helloMessage = event;
+
+            // save requested role of the client
+            root_machine(fsm).clientRoles[helloMessage.getClientId()] = helloMessage.getRole();
+
             // Client ID is already assigned here, gets assigned directly after server receives hello callback from network
             spy::network::messages::HelloReply helloReply{
                     helloMessage.getClientId(),

--- a/src/game/GameFSM.hpp
+++ b/src/game/GameFSM.hpp
@@ -239,14 +239,14 @@ class GameFSM : public afsm::def::state_machine<GameFSM> {
 
                 // @formatter:off
                 using internal_transitions = transition_table <
-                // Event                                  Action                                                                                                                   Guard
-                in<spy::network::messages::GameOperation, actions::multiple<actions::handleOperation, actions::broadcastState, actions::requestNextOperation>,                     guards::operationValid>,
+                // Event                                  Action                                                                                                                                                                               Guard
+                in<spy::network::messages::GameOperation, actions::multiple<actions::handleOperation, actions::broadcastState, actions::requestNextOperation>,                                                                                 guards::operationValid>,
                 in<events::skipOperation,                 actions::multiple<actions::broadcastState, actions::requestNextOperation>>,
-                in<spy::network::messages::GameOperation, actions::multiple<actions::replyWithError<spy::network::ErrorTypeEnum::ILLEGAL_MESSAGE>, actions::requestNextOperation>, not_<guards::operationValid>>,
+                in<spy::network::messages::GameOperation, actions::multiple<actions::replyWithError<spy::network::ErrorTypeEnum::ILLEGAL_MESSAGE>, actions::closeConnectionToClient, actions::broadcastGameLeft, actions::emitForceGameClose>, not_<guards::operationValid>>,
                 in<events::triggerNPCmove,                actions::multiple<actions::generateNPCMove>>,
                 in<events::triggerCatMove,                actions::multiple<actions::executeCatMove, actions::broadcastState, actions::requestNextOperation>>,
                 in<events::triggerJanitorMove,            actions::multiple<actions::executeJanitorMove, actions::broadcastState, actions::requestNextOperation>>,
-                in<spy::network::messages::Hello,         actions::multiple<actions::HelloReply, actions::broadcastState>,                                                          guards::isSpectator>>;
+                in<spy::network::messages::Hello,         actions::multiple<actions::HelloReply, actions::broadcastState>,                                                                                                                     guards::isSpectator>>;
                 // @formatter:on
             };
 


### PR DESCRIPTION
Aufgrund der direkten Zuweisung einer Rolle bei einer HelloMessage war es möglich, dass ein Client, der die Rolle Player haben wollte, aber aufgrund von Namensdopplungen abgewiesen wurde, mit seinem Disconnect Event den Server in die Lobby brachte, unabhängig davon, dass ja noch ein Spieler verbunden blieb.

Als Fix wird die Rolle nun erst gesetzt, wenn sie mit einer HelloReply message bestätigt wird.

Außerdem werden clients nun für nicht valide Operationen gekickt.