### PR TITLE
escape quotes in log for JSON

### DIFF
--- a/execStopPost.sh
+++ b/execStopPost.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 GH_TOKEN=""
-GH:USER=""
+GH_USER=""
 URL="https://api.github.com/repos/SoPra-Team-17/Server/issues"
 if [ $EXIT_STATUS -ne 0 ]; then
     LOG=$(journalctl _SYSTEMD_INVOCATION_ID="$INVOCATION_ID")
@@ -9,7 +9,7 @@ if [ $EXIT_STATUS -ne 0 ]; then
 <summary>Log</summary>
 
 \`\`\`
-$LOG
+${LOG//\"/\\\"}
 \`\`\`
 </details>\"}"
 


### PR DESCRIPTION
Da im Log höchstwahrscheinlich JSON ist, sollten `"` escaped werden